### PR TITLE
Update solution paths and clean up workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -29,8 +29,6 @@ jobs:
     - name: Install dependencies
       run: npm ci
 
-# Removed redundant npm install step
-
     - name: Install Playwright browsers
       run: npx playwright install --with-deps
 

--- a/Obsidian.sln
+++ b/Obsidian.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.13.35919.96
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Obsidian", "Source\Obsidian\Obsidian.csproj", "{37B84949-B7E7-42AD-93F8-107FC134A53D}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Obsidian", "source\Obsidian\Obsidian.csproj", "{37B84949-B7E7-42AD-93F8-107FC134A53D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Obsidian.UnitTests", "Source\Obsidian.UnitTests\Obsidian.UnitTests.csproj", "{CABBADBD-89D2-44FB-B79F-B65407C2B31A}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Obsidian.UnitTests", "source\Obsidian.UnitTests\Obsidian.UnitTests.csproj", "{CABBADBD-89D2-44FB-B79F-B65407C2B31A}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{02EA681E-C7D8-13C7-8484-4AC65E1B71E8}"
 	ProjectSection(SolutionItems) = preProject


### PR DESCRIPTION
Changed project paths in Obsidian.sln from 'Source' to 'source' for consistency. Removed a redundant comment from the dotnet GitHub Actions workflow.